### PR TITLE
Remove unused and deprecated dep dash-functional

### DIFF
--- a/ob-cypher.el
+++ b/ob-cypher.el
@@ -7,7 +7,7 @@
 ;; Keywords: org babel cypher neo4j
 ;; Version: 0.0.1
 ;; Created: 8th Feb 2015
-;; Package-Requires: ((s "1.9.0") (cypher-mode "0.0.6") (dash "2.10.0") (dash-functional "1.2.0"))
+;; Package-Requires: ((s "1.9.0") (cypher-mode "0.0.6") (dash "2.10.0"))
 
 ;; This file is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
The project does not currently use `dash-functional`, which was recently deprecated and subsumed by `dash 2.18.0`.

See https://github.com/magnars/dash.el/blob/master/NEWS.md#from-217-to-218